### PR TITLE
fix: incorrect order of some properties in types8

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,18 +6,18 @@ import type {
 export const types8: RegistryTypes = {
   Address: "AccountId",
   Attestation: {
-    attester: "AccountId",
     ctypeHash: "Hash",
+    attester: "AccountId",
     delegationId: "Option<DelegationNodeId>",
     revoked: "bool",
   },
   Balance: "u128",
   DelegationNode: {
-    owner: "AccountId",
+    rootId: "DelegationNodeId",
     parent: "Option<DelegationNodeId>",
+    owner: "AccountId",
     permissions: "Permissions",
     revoked: "bool",
-    rootId: "DelegationNodeId",
   },
   DelegationNodeId: "Hash",
   DelegationRoot: {
@@ -26,9 +26,9 @@ export const types8: RegistryTypes = {
     revoked: "bool",
   },
   DidRecord: {
+    signKey: "Hash",
     boxKey: "Hash",
     docRef: "Option<Vec<u8>>",
-    signKey: "Hash",
   },
   Index: "u64",
   LookupSource: "AccountId",


### PR DESCRIPTION
## quick fix

## How to test:
use types8 in sdk integration tests with the latest mashnet-node release

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
