### PR TITLE
feat: explicit definition of AccountInfo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import type {
 } from "@polkadot/types/types";
 
 export const types8: RegistryTypes = {
+  AccountInfo: "AccountInfoWithDualRefCount",
   Address: "AccountId",
   Attestation: {
     ctypeHash: "Hash",
@@ -83,6 +84,7 @@ export const types8: RegistryTypes = {
 
 export const types9: RegistryTypes = {
   // Runtime types
+  AccountInfo: "AccountInfoWithTripleRefCount",
   Address: "MultiAddress",
   AmountOf: "i128",
   Balance: "u128",


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1339
Adds definitions for `AccountInfo` as the current default does not work for runtime v8

## How to test:
add the types to the polkadot apps and test (repeat for both v9 and v8 runtime)

## Checklist:

- [x] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
