### PR TITLE
feat: add types for staking

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,4 @@
-import type {
-  OverrideBundleDefinition,
-  RegistryTypes,
-} from "@polkadot/types/types";
+import type { OverrideBundleDefinition, RegistryTypes } from "@polkadot/types/types";
 
 export const types8: RegistryTypes = {
   AccountInfo: "AccountInfoWithDualRefCount",
@@ -148,12 +145,7 @@ export const types9: RegistryTypes = {
     },
   },
   DidVerificationKeyRelationship: {
-    _enum: [
-      "Authentication",
-      "CapabilityDelegation",
-      "CapabilityInvocation",
-      "AssertionMethod",
-    ],
+    _enum: ["Authentication", "CapabilityDelegation", "CapabilityInvocation", "AssertionMethod"],
   },
   DidSignature: {
     _enum: {
@@ -259,6 +251,230 @@ export const types9: RegistryTypes = {
   },
 };
 
+export const types10: RegistryTypes = {
+  // Runtime
+  AccountInfo: "AccountInfoWithTripleRefCount",
+  Address: "MultiAddress",
+  AmountOf: "i128",
+  Balance: "u128",
+  BlockNumber: "u64",
+  Index: "u64",
+  LookupSource: "MultiAddress",
+
+  // Ctypes
+  CtypeCreatorOf: "DidIdentifierOf",
+  CtypeHashOf: "Hash",
+  ClaimHashOf: "Hash",
+
+  // Attestations
+  AttesterOf: "DidIdentifierOf",
+  AttestationDetails: {
+    ctypeHash: "CtypeHashOf",
+    attester: "AttesterOf",
+    delegationId: "Option<DelegationNodeIdOf>",
+    revoked: "bool",
+  },
+
+  // Delegations
+  Permissions: "u32",
+  DelegationNodeIdOf: "Hash",
+  DelegatorIdOf: "DidIdentifierOf",
+  DelegationSignature: "DidSignature",
+  DelegationRoot: {
+    ctypeHash: "CtypeHashOf",
+    owner: "DelegatorIdOf",
+    revoked: "bool",
+  },
+  DelegationNode: {
+    rootId: "DelegationNodeIdOf",
+    parent: "Option<DelegationNodeIdOf>",
+    owner: "DelegatorIdOf",
+    permissions: "Permissions",
+    revoked: "bool",
+  },
+
+  // DIDs
+  KeyIdOf: "Hash",
+  DidIdentifierOf: "AccountId",
+  AccountIdentifierOf: "AccountId",
+  BlockNumberOf: "BlockNumber",
+  DidCallableOf: "Call",
+  DidVerificationKey: {
+    _enum: {
+      Ed25519: "[u8; 32]",
+      Sr25519: "[u8; 32]",
+    },
+  },
+  DidEncryptionKey: {
+    _enum: {
+      X25519: "[u8; 32]",
+    },
+  },
+  DidPublicKey: {
+    _enum: {
+      PublicVerificationKey: "DidVerificationKey",
+      PublicEncryptionKey: "DidEncryptionKey",
+    },
+  },
+  DidVerificationKeyRelationship: {
+    _enum: ["Authentication", "CapabilityDelegation", "CapabilityInvocation", "AssertionMethod"],
+  },
+  DidSignature: {
+    _enum: {
+      Ed25519: "Ed25519Signature",
+      Sr25519: "Sr25519Signature",
+    },
+  },
+  DidError: {
+    _enum: {
+      StorageError: "StorageError",
+      SignatureError: "SignatureError",
+      UrlError: "UrlError",
+      InternalError: "Null",
+    },
+  },
+  StorageError: {
+    _enum: {
+      DidAlreadyPresent: "Null",
+      DidNotPresent: "Null",
+      DidKeyNotPresent: "DidVerificationKeyRelationship",
+      VerificationKeyNotPresent: "Null",
+      CurrentlyActiveKey: "Null",
+      MaxTxCounterValue: "Null",
+    },
+  },
+  SignatureError: {
+    _enum: ["InvalidSignatureFormat", "InvalidSignature", "InvalidNonce"],
+  },
+  KeyError: {
+    _enum: ["InvalidVerificationKeyFormat", "InvalidEncryptionKeyFormat"],
+  },
+  UrlError: {
+    _enum: ["InvalidUrlEncoding", "InvalidUrlScheme"],
+  },
+  DidPublicKeyDetails: {
+    key: "DidPublicKey",
+    blockNumber: "BlockNumberOf",
+  },
+  DidDetails: {
+    authenticationKey: "KeyIdOf",
+    keyAgreementKeys: "BTreeSet<KeyIdOf>",
+    delegationKey: "Option<KeyIdOf>",
+    attestationKey: "Option<KeyIdOf>",
+    publicKeys: "BTreeMap<KeyIdOf, DidPublicKeyDetails>",
+    endpointUrl: "Option<Url>",
+    lastTxCounter: "u64",
+  },
+  DidCreationOperation: {
+    did: "DidIdentifierOf",
+    newAuthenticationKey: "DidVerificationKey",
+    newKeyAgreementKeys: "BTreeSet<DidEncryptionKey>",
+    newAttestationKey: "Option<DidVerificationKey>",
+    newDelegationKey: "Option<DidVerificationKey>",
+    newEndpointUrl: "Option<Url>",
+  },
+  DidUpdateOperation: {
+    did: "DidIdentifierOf",
+    newAuthenticationKey: "Option<DidVerificationKey>",
+    newKeyAgreementKeys: "BTreeSet<DidEncryptionKey>",
+    attestationKeyUpdate: "DidVerificationKeyUpdateAction",
+    delegationKeyUpdate: "DidVerificationKeyUpdateAction",
+    publicKeysToRemove: "BTreeSet<KeyIdOf>",
+    newEndpointUrl: "Option<Url>",
+    txCounter: "u64",
+  },
+  DidVerificationKeyUpdateAction: {
+    _enum: {
+      Ignore: "Null",
+      Change: "DidVerificationKey",
+      Delete: "Null",
+    },
+  },
+  DidDeletionOperation: {
+    did: "DidIdentifierOf",
+    txCounter: "u64",
+  },
+  DidAuthorizedCallOperation: {
+    did: "DidIdentifierOf",
+    txCounter: "u64",
+    call: "DidCallableOf",
+  },
+  HttpUrl: {
+    payload: "Text",
+  },
+  FtpUrl: {
+    payload: "Text",
+  },
+  IpfsUrl: {
+    payload: "Text",
+  },
+  Url: {
+    _enum: {
+      Http: "HttpUrl",
+      Ftp: "FtpUrl",
+      Ipfs: "IpfsUrl",
+    },
+  },
+
+  // LaunchPallet
+  LockedBalance: {
+    block: "BlockNumber",
+    amount: "Balance",
+  },
+
+  // Staking
+  RoundIndex: "u32",
+  RoundInfo: {
+    current: "RoundIndex",
+    first: "BlockNumber",
+    length: "BlockNumber",
+  },
+  OrderedSet: "Vec<Stake>",
+  Stake: {
+    owner: "AccountId",
+    amount: "Balance",
+  },
+  TotalStake: {
+    collators: "Balance",
+    delegators: "Balance",
+  },
+  InflationInfo: {
+    collator: "StakingInfo",
+    delegator: "StakingInfo",
+  },
+  StakingInfo: {
+    maxRate: "Perquintill",
+    rewardRate: "RewardRate",
+  },
+  RewardRate: {
+    annual: "Perquintill",
+    perBlock: "Perquintill",
+  },
+  Delegator: {
+    delegations: "Vec<Stake>",
+    total: "Balance",
+  },
+  CollatorSnapshot: {
+    stake: "Balance",
+    delegators: "Vec<Stake>",
+    total: "Balance",
+  },
+  Collator: {
+    id: "AccountId",
+    stake: "Balance",
+    delegators: "Vec<Stake>",
+    total: "Balance",
+    state: "CollatorStatus",
+  },
+  CollatorStatus: {
+    _enum: {
+      Active: "Null",
+      Idle: "Null",
+      Leaving: "SessionIndex",
+    },
+  },
+};
+
 export const typeBundleForPolkadot: OverrideBundleDefinition = {
   types: [
     {
@@ -266,8 +482,12 @@ export const typeBundleForPolkadot: OverrideBundleDefinition = {
       types: types8,
     },
     {
-      minmax: [9, undefined],
+      minmax: [9, 9],
       types: types9,
+    },
+    {
+      minmax: [10, undefined],
+      types: types10,
     },
   ],
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -464,18 +464,18 @@ export const types10: RegistryTypes = {
     perBlock: "Perquintill",
   },
   Delegator: {
-    delegations: "OrderedSet",
+    delegations: "Vec<Stake>",
     total: "Balance",
   },
   CollatorSnapshot: {
     stake: "Balance",
-    delegators: "OrderedSet",
+    delegators: "Vec<Stake>",
     total: "Balance",
   },
   Collator: {
     id: "AccountId",
     stake: "Balance",
-    delegators: "OrderedSet",
+    delegators: "Vec<Stake>",
     total: "Balance",
     state: "CollatorStatus",
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
-import type { OverrideBundleDefinition, RegistryTypes } from "@polkadot/types/types";
+import type {
+  OverrideBundleDefinition,
+  RegistryTypes,
+} from "@polkadot/types/types";
 
 export const types8: RegistryTypes = {
   AccountInfo: "AccountInfoWithDualRefCount",
@@ -145,7 +148,12 @@ export const types9: RegistryTypes = {
     },
   },
   DidVerificationKeyRelationship: {
-    _enum: ["Authentication", "CapabilityDelegation", "CapabilityInvocation", "AssertionMethod"],
+    _enum: [
+      "Authentication",
+      "CapabilityDelegation",
+      "CapabilityInvocation",
+      "AssertionMethod",
+    ],
   },
   DidSignature: {
     _enum: {
@@ -317,7 +325,12 @@ export const types10: RegistryTypes = {
     },
   },
   DidVerificationKeyRelationship: {
-    _enum: ["Authentication", "CapabilityDelegation", "CapabilityInvocation", "AssertionMethod"],
+    _enum: [
+      "Authentication",
+      "CapabilityDelegation",
+      "CapabilityInvocation",
+      "AssertionMethod",
+    ],
   },
   DidSignature: {
     _enum: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -423,9 +423,9 @@ export const types10: RegistryTypes = {
   },
 
   // Staking
-  RoundIndex: "u32",
+  BalanceOf: "Balance",
   RoundInfo: {
-    current: "RoundIndex",
+    current: "SessionIndex",
     first: "BlockNumber",
     length: "BlockNumber",
   },
@@ -451,25 +451,24 @@ export const types10: RegistryTypes = {
     perBlock: "Perquintill",
   },
   Delegator: {
-    delegations: "Vec<Stake>",
+    delegations: "OrderedSet",
     total: "Balance",
   },
   CollatorSnapshot: {
     stake: "Balance",
-    delegators: "Vec<Stake>",
+    delegators: "OrderedSet",
     total: "Balance",
   },
   Collator: {
     id: "AccountId",
     stake: "Balance",
-    delegators: "Vec<Stake>",
+    delegators: "OrderedSet",
     total: "Balance",
     state: "CollatorStatus",
   },
   CollatorStatus: {
     _enum: {
       Active: "Null",
-      Idle: "Null",
       Leaving: "SessionIndex",
     },
   },


### PR DESCRIPTION
## adds types introduced in KILTProtocol/ticket#1253
[Mashnet companion](https://github.com/KILTprotocol/mashnet-node/pull/145)

<details>
  <summary>JS-Types</summary>
  
  ```json
{
  "AccountInfo": "AccountInfoWithTripleRefCount",
  "Address": "MultiAddress",
  "AmountOf": "i128",
  "Balance": "u128",
  "BlockNumber": "u64",
  "Index": "u64",
  "LookupSource": "MultiAddress",
  "CtypeCreatorOf": "DidIdentifierOf",
  "CtypeHashOf": "Hash",
  "ClaimHashOf": "Hash",
  "AttesterOf": "DidIdentifierOf",
  "AttestationDetails": {
    "ctypeHash": "CtypeHashOf",
    "attester": "AttesterOf",
    "delegationId": "Option<DelegationNodeIdOf>",
    "revoked": "bool"
  },
  "Permissions": "u32",
  "DelegationNodeIdOf": "Hash",
  "DelegatorIdOf": "DidIdentifierOf",
  "DelegationSignature": "DidSignature",
  "DelegationRoot": {
    "ctypeHash": "CtypeHashOf",
    "owner": "DelegatorIdOf",
    "revoked": "bool"
  },
  "DelegationNode": {
    "rootId": "DelegationNodeIdOf",
    "parent": "Option<DelegationNodeIdOf>",
    "owner": "DelegatorIdOf",
    "permissions": "Permissions",
    "revoked": "bool"
  },
  "KeyIdOf": "Hash",
  "DidIdentifierOf": "AccountId",
  "AccountIdentifierOf": "AccountId",
  "BlockNumberOf": "BlockNumber",
  "DidCallableOf": "Call",
  "DidVerificationKey": {
    "_enum": {
      "Ed25519": "[u8; 32]",
      "Sr25519": "[u8; 32]"
    }
  },
  "DidEncryptionKey": {
    "_enum": {
      "X25519": "[u8; 32]"
    }
  },
  "DidPublicKey": {
    "_enum": {
      "PublicVerificationKey": "DidVerificationKey",
      "PublicEncryptionKey": "DidEncryptionKey"
    }
  },
  "DidVerificationKeyRelationship": {
    "_enum": [
      "Authentication",
      "CapabilityDelegation",
      "CapabilityInvocation",
      "AssertionMethod"
    ]
  },
  "DidSignature": {
    "_enum": {
      "Ed25519": "Ed25519Signature",
      "Sr25519": "Sr25519Signature"
    }
  },
  "DidError": {
    "_enum": {
      "StorageError": "StorageError",
      "SignatureError": "SignatureError",
      "UrlError": "UrlError",
      "InternalError": "Null"
    }
  },
  "StorageError": {
    "_enum": {
      "DidAlreadyPresent": "Null",
      "DidNotPresent": "Null",
      "DidKeyNotPresent": "DidVerificationKeyRelationship",
      "VerificationKeyNotPresent": "Null",
      "CurrentlyActiveKey": "Null",
      "MaxTxCounterValue": "Null"
    }
  },
  "SignatureError": {
    "_enum": [
      "InvalidSignatureFormat",
      "InvalidSignature",
      "InvalidNonce"
    ]
  },
  "KeyError": {
    "_enum": [
      "InvalidVerificationKeyFormat",
      "InvalidEncryptionKeyFormat"
    ]
  },
  "UrlError": {
    "_enum": [
      "InvalidUrlEncoding",
      "InvalidUrlScheme"
    ]
  },
  "DidPublicKeyDetails": {
    "key": "DidPublicKey",
    "blockNumber": "BlockNumberOf"
  },
  "DidDetails": {
    "authenticationKey": "KeyIdOf",
    "keyAgreementKeys": "BTreeSet<KeyIdOf>",
    "delegationKey": "Option<KeyIdOf>",
    "attestationKey": "Option<KeyIdOf>",
    "publicKeys": "BTreeMap<KeyIdOf, DidPublicKeyDetails>",
    "endpointUrl": "Option<Url>",
    "lastTxCounter": "u64"
  },
  "DidCreationOperation": {
    "did": "DidIdentifierOf",
    "newAuthenticationKey": "DidVerificationKey",
    "newKeyAgreementKeys": "BTreeSet<DidEncryptionKey>",
    "newAttestationKey": "Option<DidVerificationKey>",
    "newDelegationKey": "Option<DidVerificationKey>",
    "newEndpointUrl": "Option<Url>"
  },
  "DidUpdateOperation": {
    "did": "DidIdentifierOf",
    "newAuthenticationKey": "Option<DidVerificationKey>",
    "newKeyAgreementKeys": "BTreeSet<DidEncryptionKey>",
    "attestationKeyUpdate": "DidVerificationKeyUpdateAction",
    "delegationKeyUpdate": "DidVerificationKeyUpdateAction",
    "publicKeysToRemove": "BTreeSet<KeyIdOf>",
    "newEndpointUrl": "Option<Url>",
    "txCounter": "u64"
  },
  "DidVerificationKeyUpdateAction": {
    "_enum": {
      "Ignore": "Null",
      "Change": "DidVerificationKey",
      "Delete": "Null"
    }
  },
  "DidDeletionOperation": {
    "did": "DidIdentifierOf",
    "txCounter": "u64"
  },
  "DidAuthorizedCallOperation": {
    "did": "DidIdentifierOf",
    "txCounter": "u64",
    "call": "DidCallableOf"
  },
  "HttpUrl": {
    "payload": "Text"
  },
  "FtpUrl": {
    "payload": "Text"
  },
  "IpfsUrl": {
    "payload": "Text"
  },
  "Url": {
    "_enum": {
      "Http": "HttpUrl",
      "Ftp": "FtpUrl",
      "Ipfs": "IpfsUrl"
    }
  },
  "LockedBalance": {
    "block": "BlockNumber",
    "amount": "Balance"
  },
  "BalanceOf": "Balance",
  "RoundInfo": {
    "current": "SessionIndex",
    "first": "BlockNumber",
    "length": "BlockNumber"
  },
  "OrderedSet": "Vec<Stake>",
  "Stake": {
    "owner": "AccountId",
    "amount": "Balance"
  },
  "TotalStake": {
    "collators": "Balance",
    "delegators": "Balance"
  },
  "InflationInfo": {
    "collator": "StakingInfo",
    "delegator": "StakingInfo"
  },
  "StakingInfo": {
    "maxRate": "Perquintill",
    "rewardRate": "RewardRate"
  },
  "RewardRate": {
    "annual": "Perquintill",
    "perBlock": "Perquintill"
  },
  "Delegator": {
    "delegations": "Vec<Stake>",
    "total": "Balance"
  },
  "CollatorSnapshot": {
    "stake": "Balance",
    "delegators": "Vec<Stake>",
    "total": "Balance"
  },
  "Collator": {
    "id": "AccountId",
    "stake": "Balance",
    "delegators": "Vec<Stake>",
    "total": "Balance",
    "state": "CollatorStatus"
  },
  "CollatorStatus": {
    "_enum": {
      "Active": "Null",
      "Leaving": "SessionIndex"
    }
  }
}
  ```
</details>

