### PR TITLE
chore: release 0.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,5 @@
     "@polkadot/types": "^3.11.1",
     "typescript": "^3.9.7"
   },
-  "version": "0.1.6"
+  "version": "0.1.7"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -270,12 +270,12 @@ export const types10: RegistryTypes = {
   LookupSource: "MultiAddress",
 
   // Ctypes
-  CtypeCreatorOf: "DidIdentifierOf",
+  CtypeCreatorOf: "AccountId",
   CtypeHashOf: "Hash",
   ClaimHashOf: "Hash",
 
   // Attestations
-  AttesterOf: "DidIdentifierOf",
+  AttesterOf: "AccountId",
   AttestationDetails: {
     ctypeHash: "CtypeHashOf",
     attester: "AttesterOf",
@@ -286,8 +286,8 @@ export const types10: RegistryTypes = {
   // Delegations
   Permissions: "u32",
   DelegationNodeIdOf: "Hash",
-  DelegatorIdOf: "DidIdentifierOf",
-  DelegationSignature: "DidSignature",
+  DelegatorIdOf: "AccountId",
+  DelegateSignatureTypeOf: "Vec<u8>",
   DelegationRoot: {
     ctypeHash: "CtypeHashOf",
     owner: "DelegatorIdOf",


### PR DESCRIPTION
We have one additional type required for the delegation pallet.
I also changed the owner type of Delegation / CType / Attestation to be `AccountId`. This does not effectively change the type, as the `DidIdentifierOf` was just an alias for `AccountId`, but avoids confusion where we are not using the did origin yet (e.g. peregrine).