### PR TITLE
feat: types for new delegation pallet (runtime version 17)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,5 @@
     "@polkadot/types": "^3.11.1",
     "typescript": "^3.9.7"
   },
-  "version": "0.1.9"
+  "version": "0.1.10"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -506,7 +506,7 @@ export const types17: RegistryTypes = {
   ...types12,
   // Delegation updated types
   DelegationNode: {
-    hierarchy_root_id: "DelegationNodeIdOf",
+    hierarchyRootId: "DelegationNodeIdOf",
     parent: "Option<DelegationNodeIdOf>",
     children: "BTreeSet<DelegationNodeIdOf>",
     details: "DelegationDetails",
@@ -517,7 +517,7 @@ export const types17: RegistryTypes = {
     permissions: "Permissions",
   },
   DelegationHierarchyDetails: {
-    ctype_hash: "CtypeHashOf",
+    ctypeHash: "CtypeHashOf",
   },
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -502,6 +502,25 @@ export const types12: RegistryTypes = {
   },
 };
 
+export const types17: RegistryTypes = {
+  ...types12,
+  // Delegation updated types
+  DelegationNode: {
+    hierarchy_root_id: "DelegationNodeIdOf",
+    parent: "Option<DelegationNodeIdOf>",
+    children: "BTreeSet<DelegationNodeIdOf>",
+    details: "DelegationDetails",
+  },
+  DelegationDetails: {
+    owner: "DelegatorIdOf",
+    revoked: "bool",
+    permissions: "Permissions",
+  },
+  DelegationHierarchyDetails: {
+    ctype_hash: "CtypeHashOf",
+  },
+};
+
 export const typeBundleForPolkadot: OverrideBundleDefinition = {
   types: [
     {
@@ -517,8 +536,12 @@ export const typeBundleForPolkadot: OverrideBundleDefinition = {
       types: types10,
     },
     {
-      minmax: [12, undefined],
+      minmax: [12, 16],
       types: types12,
+    },
+    {
+      minmax: [17, undefined],
+      types: types17,
     },
   ],
 };


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1451
Adds the new types for `DelegationNode`, `DelegationHierarchy`, and `DelegationDetails`.

## How to test:
Try to create a new CTYPE hash and then a new delegation hierarchy. After that, you should be able to retrieve the correct delegation node info from the chain storage.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
