### PR TITLE
feat: integrate new types for DID origin in DID update and deletion

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,5 @@
     "@polkadot/types": "^3.11.1",
     "typescript": "^3.9.7"
   },
-  "version": "0.1.9"
+  "version": "0.1.10"
 }

--- a/package.json
+++ b/package.json
@@ -19,5 +19,5 @@
     "@polkadot/types": "^3.11.1",
     "typescript": "^3.9.7"
   },
-  "version": "0.1.10"
+  "version": "0.1.12"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -523,6 +523,11 @@ export const types17: RegistryTypes = {
 
 export const types18: RegistryTypes = {
   ...types17,
+  // Remove old DID types
+  DidCreationOperation: undefined,
+  DidUpdateOperation: undefined,
+  DidDeletionOperation: undefined,
+
   // DID management update
   DidCreationDetails: {
     did: "DidIdentifierOf",

--- a/src/index.ts
+++ b/src/index.ts
@@ -506,7 +506,7 @@ export const types17: RegistryTypes = {
   ...types12,
   // Delegation updated types
   DelegationNode: {
-    hierarchy_root_id: "DelegationNodeIdOf",
+    hierarchyRootId: "DelegationNodeIdOf",
     parent: "Option<DelegationNodeIdOf>",
     children: "BTreeSet<DelegationNodeIdOf>",
     details: "DelegationDetails",
@@ -517,7 +517,7 @@ export const types17: RegistryTypes = {
     permissions: "Permissions",
   },
   DelegationHierarchyDetails: {
-    ctype_hash: "CtypeHashOf",
+    ctypeHash: "CtypeHashOf",
   },
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -502,6 +502,25 @@ export const types12: RegistryTypes = {
   },
 };
 
+export const types17: RegistryTypes = {
+  ...types12,
+  // Delegation updated types
+  DelegationNode: {
+    hierarchy_root_id: "DelegationNodeIdOf",
+    parent: "Option<DelegationNodeIdOf>",
+    children: "BTreeSet<DelegationNodeIdOf>",
+    details: "DelegationDetails",
+  },
+  DelegationDetails: {
+    owner: "DelegatorIdOf",
+    revoked: "bool",
+    permissions: "Permissions",
+  },
+  DelegationHierarchyDetails: {
+    ctype_hash: "CtypeHashOf",
+  },
+};
+
 export const typeBundleForPolkadot: OverrideBundleDefinition = {
   types: [
     {
@@ -517,8 +536,12 @@ export const typeBundleForPolkadot: OverrideBundleDefinition = {
       types: types10,
     },
     {
-      minmax: [12, undefined],
+      minmax: [12, 16],
       types: types12,
+    },
+    {
+      minmax: [17, undefined],
+      types: types17,
     },
   ],
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -521,6 +521,26 @@ export const types17: RegistryTypes = {
   },
 };
 
+export const types18: RegistryTypes = {
+  ...types17,
+  // DID management update
+  DidCreationDetails: {
+    did: "DidIdentifierOf",
+    newKeyAgreementKeys: "BTreeSet<DidEncryptionKey>",
+    newAttestationKey: "Option<DidVerificationKey>",
+    newDelegationKey: "Option<DidVerificationKey>",
+    newEndpointUrl: "Option<Url>",
+  },
+  DidUpdateDetails: {
+    newAuthenticationKey: "Option<DidVerificationKey>",
+    newKeyAgreementKeys: "BTreeSet<DidEncryptionKey>",
+    attestationKeyUpdate: "DidVerificationKeyUpdateAction",
+    delegationKeyUpdate: "DidVerificationKeyUpdateAction",
+    publicKeysToRemove: "BTreeSet<KeyIdOf>",
+    newEndpointUrl: "Option<Url>",
+  },
+};
+
 export const typeBundleForPolkadot: OverrideBundleDefinition = {
   types: [
     {
@@ -540,8 +560,12 @@ export const typeBundleForPolkadot: OverrideBundleDefinition = {
       types: types12,
     },
     {
-      minmax: [17, undefined],
+      minmax: [17, 17],
       types: types17,
+    },
+    {
+      minmax: [18, undefined],
+      types: types18,
     },
   ],
 };


### PR DESCRIPTION
## fixes KILTProtocol/ticket#312
Please include a summary of the changes provided with this pull request and which issue has been fixed. 
Changes `DidCreationOperation` to `DidCreationDetails` and `DidUpdateOperation` to `DidUpdateDetails`, removing `tx_counter` from the struct as checks are performed at the dispatch layer.