### PR TITLE
ci: add build step to workflow

### DIFF
--- a/.github/workflows/yarnbuild.yml
+++ b/.github/workflows/yarnbuild.yml
@@ -1,0 +1,19 @@
+name: release
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Build package
+        run: yarn run build


### PR DESCRIPTION
Adds `yarn build` to CI for PRs against master. This would have caught the build error after merging #13.

The pipeline is expected to fail right now. I would propose to merge this before #14.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
