### PR TITLE
did integration / quality of life improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,5 @@
     "@polkadot/types": "^5.3.1",
     "typescript": "^4.3.5"
   },
-  "version": "0.1.13"
+  "version": "0.1.14"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -751,6 +751,13 @@ export const types21: RegistryTypes = {
   },
   // removed
   DidUpdateDetails: undefined,
+  DidCreationDetails: {
+    did: "DidIdentifierOf",
+    newKeyAgreementKeys: "DidNewKeyAgreementKeys",
+    newAssertionMethodKey: "Option<DidVerificationKey>",
+    newCapabilityDelegationKey: "Option<DidVerificationKey>",
+    newServiceEndpoints: "Option<ServiceEndpoints>",
+  },
   DidDetails: {
     authenticationKey: "KeyIdOf",
     keyAgreementKeys: "DidKeyAgreementKeys",
@@ -763,6 +770,9 @@ export const types21: RegistryTypes = {
     lastTxCounter: "u64",
   },
   DelegateSignatureTypeOf: "DidSignature",
+  ContentType: {
+    _enum: ["application/json", "application/ld+json"],
+  },
 
   // fix: generics mostly don't work here, but OrderedSet is reduced to a Vec anyway
   OrderedSet: undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -507,14 +507,14 @@ export const types12: RegistryTypes = {
     _enum: {
       Ed25519: "[u8; 32]",
       Sr25519: "[u8; 32]",
-      EcdsaSecp256k1: "[u8; 33]",
+      Secp256k1: "[u8; 33]",
     },
   },
   DidSignature: {
     _enum: {
       Ed25519: "Ed25519Signature",
       Sr25519: "Sr25519Signature",
-      EcdsaSecp256k1: "EcdsaSignature",
+      "Ecdsa-Secp256k1": "EcdsaSignature",
     },
   },
 };
@@ -659,6 +659,7 @@ export const types20: RegistryTypes = {
   MaxClaims: "u32",
 
   // Delegation
+  DelegateSignatureTypeOf: "DidSignature",
   DelegationNode: {
     hierarchyRootId: "DelegationNodeIdOf",
     parent: "Option<DelegationNodeIdOf>",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
-import type { OverrideBundleDefinition, RegistryTypes } from "@polkadot/types/types";
+import type {
+  OverrideBundleDefinition,
+  RegistryTypes,
+} from "@polkadot/types/types";
 
 export const types8: RegistryTypes = {
   AccountInfo: "AccountInfoWithDualRefCount",
@@ -145,7 +148,12 @@ export const types9: RegistryTypes = {
     },
   },
   DidVerificationKeyRelationship: {
-    _enum: ["Authentication", "CapabilityDelegation", "CapabilityInvocation", "AssertionMethod"],
+    _enum: [
+      "Authentication",
+      "CapabilityDelegation",
+      "CapabilityInvocation",
+      "AssertionMethod",
+    ],
   },
   DidSignature: {
     _enum: {
@@ -317,7 +325,12 @@ export const types10: RegistryTypes = {
     },
   },
   DidVerificationKeyRelationship: {
-    _enum: ["Authentication", "CapabilityDelegation", "CapabilityInvocation", "AssertionMethod"],
+    _enum: [
+      "Authentication",
+      "CapabilityDelegation",
+      "CapabilityInvocation",
+      "AssertionMethod",
+    ],
   },
   DidSignature: {
     _enum: {
@@ -354,7 +367,11 @@ export const types10: RegistryTypes = {
     _enum: ["InvalidUrlEncoding", "InvalidUrlScheme"],
   },
   InputError: {
-    _enum: ["MaxKeyAgreementKeysLimitExceeded", "MaxVerificationKeysToRemoveLimitExceeded", "MaxUrlLengthExceeded"],
+    _enum: [
+      "MaxKeyAgreementKeysLimitExceeded",
+      "MaxVerificationKeysToRemoveLimitExceeded",
+      "MaxUrlLengthExceeded",
+    ],
   },
   DidPublicKeyDetails: {
     key: "DidPublicKey",
@@ -576,7 +593,7 @@ export const types19: RegistryTypes = {
     },
   },
   ContentType: {
-    _enum: ["ApplicationJson", "ApplicationJsonLd"],
+    _enum: ["application/json", "application/ld+json"],
   },
 
   // Updated types
@@ -652,27 +669,30 @@ export const types20: RegistryTypes = {
   MaxChildren: "u32",
 
   // DIDs
-  DidNewKeyAgreementKeys: "BoundedBTreeSet<DidEncryptionKey, MaxNewKeyAgreementKeys>",
+  DidNewKeyAgreementKeys:
+    "BoundedBTreeSet<DidEncryptionKey, MaxNewKeyAgreementKeys>",
   DidKeyAgreementKeys: "BoundedBTreeSet<KeyIdOf, MaxTotalKeyAgreementKeys>",
-  DidVerificationKeysToRevoke: "BoundedBTreeSet<KeyIdOf, MaxVerificationKeysToRevoke>",
+  DidVerificationKeysToRevoke:
+    "BoundedBTreeSet<KeyIdOf, MaxVerificationKeysToRevoke>",
   MaxNewKeyAgreementKeys: "u32",
   MaxTotalKeyAgreementKeys: "u32",
   MaxVerificationKeysToRevoke: "u32",
   MaxPublicKeysPerDid: "u32",
-  DidPublicKeyMap: "BoundedBTreeMap<KeyIdOf, DidPublicKeyDetails, MaxPublicKeysPerDid>",
+  DidPublicKeyMap:
+    "BoundedBTreeMap<KeyIdOf, DidPublicKeyDetails, MaxPublicKeysPerDid>",
   DidCreationDetails: {
     did: "DidIdentifierOf",
     newKeyAgreementKeys: "DidNewKeyAgreementKeys",
-    newAttestationKey: "Option<DidVerificationKey>",
-    newDelegationKey: "Option<DidVerificationKey>",
+    newAssertionMethodKey: "Option<DidVerificationKey>",
+    newCapabilityDelegationKey: "Option<DidVerificationKey>",
     newServiceEndpoints: "Option<ServiceEndpoints>",
   },
   DidUpdateDetails: {
     newAuthenticationKey: "Option<DidVerificationKey>",
     // new
     newKeyAgreementKeys: "DidNewKeyAgreementKeys",
-    attestationKeyUpdate: "DidFragmentUpdateAction_DidVerificationKey",
-    delegationKeyUpdate: "DidFragmentUpdateAction_DidVerificationKey",
+    assertionMethodKeyUpdate: "DidFragmentUpdateAction_DidVerificationKey",
+    capabilityDelegationUpdate: "DidFragmentUpdateAction_DidVerificationKey",
     // new
     publicKeysToRemove: "DidVerificationKeysToRevoke",
     serviceEndpointsUpdate: "DidFragmentUpdateAction_ServiceEndpoints",
@@ -681,8 +701,8 @@ export const types20: RegistryTypes = {
     authenticationKey: "KeyIdOf",
     // new
     keyAgreementKeys: "DidKeyAgreementKeys",
-    delegationKey: "Option<KeyIdOf>",
-    attestationKey: "Option<KeyIdOf>",
+    capabilityDelegationKey: "Option<KeyIdOf>",
+    assertionMethodKey: "Option<KeyIdOf>",
     // new
     publicKeys: "DidPublicKeyMap",
     serviceEndpoints: "Option<ServiceEndpoints>",
@@ -707,7 +727,7 @@ export const types20: RegistryTypes = {
       // new
       MaxPublicKeysPerDidKeyIdentifierExceeded: "Null",
       MaxTotalKeyAgreementKeysExceeded: "Null",
-      MaxOldAttestationKeysExceeded: "Null",
+      MaxOldAssertionMethodKeysExceeded: "Null",
     },
   },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -593,7 +593,7 @@ export const types19: RegistryTypes = {
     },
   },
   ContentType: {
-    _enum: ["application/json", "application/ld+json"],
+    _enum: ["ApplicationJson", "ApplicationJsonLd"],
   },
 
   // Updated types
@@ -659,7 +659,6 @@ export const types20: RegistryTypes = {
   MaxClaims: "u32",
 
   // Delegation
-  DelegateSignatureTypeOf: "DidSignature",
   DelegationNode: {
     hierarchyRootId: "DelegationNodeIdOf",
     parent: "Option<DelegationNodeIdOf>",
@@ -684,16 +683,16 @@ export const types20: RegistryTypes = {
   DidCreationDetails: {
     did: "DidIdentifierOf",
     newKeyAgreementKeys: "DidNewKeyAgreementKeys",
-    newAssertionMethodKey: "Option<DidVerificationKey>",
-    newCapabilityDelegationKey: "Option<DidVerificationKey>",
+    newAttestationKey: "Option<DidVerificationKey>",
+    newDelegationKey: "Option<DidVerificationKey>",
     newServiceEndpoints: "Option<ServiceEndpoints>",
   },
   DidUpdateDetails: {
     newAuthenticationKey: "Option<DidVerificationKey>",
     // new
     newKeyAgreementKeys: "DidNewKeyAgreementKeys",
-    assertionMethodKeyUpdate: "DidFragmentUpdateAction_DidVerificationKey",
-    capabilityDelegationUpdate: "DidFragmentUpdateAction_DidVerificationKey",
+    attestationKeyUpdate: "DidFragmentUpdateAction_DidVerificationKey",
+    delegationKeyUpdate: "DidFragmentUpdateAction_DidVerificationKey",
     // new
     publicKeysToRemove: "DidVerificationKeysToRevoke",
     serviceEndpointsUpdate: "DidFragmentUpdateAction_ServiceEndpoints",
@@ -702,8 +701,8 @@ export const types20: RegistryTypes = {
     authenticationKey: "KeyIdOf",
     // new
     keyAgreementKeys: "DidKeyAgreementKeys",
-    capabilityDelegationKey: "Option<KeyIdOf>",
-    assertionMethodKey: "Option<KeyIdOf>",
+    delegationKey: "Option<KeyIdOf>",
+    attestationKey: "Option<KeyIdOf>",
     // new
     publicKeys: "DidPublicKeyMap",
     serviceEndpoints: "Option<ServiceEndpoints>",
@@ -728,8 +727,57 @@ export const types20: RegistryTypes = {
       // new
       MaxPublicKeysPerDidKeyIdentifierExceeded: "Null",
       MaxTotalKeyAgreementKeysExceeded: "Null",
-      MaxOldAssertionMethodKeysExceeded: "Null",
+      MaxOldAttestationKeysExceeded: "Null",
     },
+  },
+};
+
+export const types21: RegistryTypes = {
+  ...types20,
+
+  StorageError: {
+    _enum: {
+      DidAlreadyPresent: "Null",
+      DidNotPresent: "Null",
+      DidKeyNotPresent: "DidVerificationKeyRelationship",
+      VerificationKeyNotPresent: "Null",
+      CurrentlyActiveKey: "Null",
+      MaxTxCounterValue: "Null",
+      MaxPublicKeysPerDidKeyIdentifierExceeded: "Null",
+      // renamed
+      MaxTotalKeyAgreementKeysExceeded: "Null",
+      MaxOldAttestationKeysExceeded: "Null",
+    },
+  },
+  // removed
+  DidUpdateDetails: undefined,
+  DidDetails: {
+    authenticationKey: "KeyIdOf",
+    keyAgreementKeys: "DidKeyAgreementKeys",
+    // renamed
+    capabilityDelegationKey: "Option<KeyIdOf>",
+    // renamed
+    assertionMethodKey: "Option<KeyIdOf>",
+    publicKeys: "DidPublicKeyMap",
+    serviceEndpoints: "Option<ServiceEndpoints>",
+    lastTxCounter: "u64",
+  },
+  DelegateSignatureTypeOf: "DidSignature",
+
+  // fix: generics mostly don't work here, but OrderedSet is reduced to a Vec anyway
+  OrderedSet: undefined,
+  Collator: {
+    id: "AccountId",
+    stake: "Balance",
+    // fix
+    delegators: "Vec<Stake>",
+    total: "Balance",
+    state: "CollatorStatus",
+  },
+  Delegator: {
+    // fix
+    delegations: "Vec<Stake>",
+    total: "Balance",
   },
 };
 
@@ -764,8 +812,12 @@ export const typeBundleForPolkadot: OverrideBundleDefinition = {
       types: types19,
     },
     {
-      minmax: [20, undefined],
+      minmax: [20, 20],
       types: types20,
+    },
+    {
+      minmax: [21, undefined],
+      types: types21,
     },
   ],
 };


### PR DESCRIPTION
## Companion PR to https://github.com/KILTprotocol/sdk-js/pull/405

This provides type updates required for the complete integration of Did functionality in the sdk.
I have renamed a few struct properties to reflect the `DidVerificationKeyRelationship` the correspond to (e.g. when we formerly added a new key with the relationship `AssertionMethod` the property was called `newAttestationKey`, which I found confusing).
I also updated the `DelegateSignatureTypeOf`, which now takes a `DidSignature`.
Lastly I updated key & signature type names, and content type values.

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
