### PR TITLE
feat: Add types for runtime 26

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { types20 } from "./types_20";
 import { types21 } from "./types_21";
 import { types23 } from "./types_23";
 import { types25 } from "./types_25";
+import { types26 } from "./types_26";
 
 export {
   types8,
@@ -24,6 +25,7 @@ export {
   types21,
   types23,
   types25,
+  types26,
 };
 
 export const typeBundleForPolkadot: OverrideBundleDefinition = {
@@ -69,8 +71,12 @@ export const typeBundleForPolkadot: OverrideBundleDefinition = {
       types: types23,
     },
     {
-      minmax: [25, undefined],
+      minmax: [25, 25],
       types: types25,
+    },
+    {
+      minmax: [26, undefined],
+      types: types26,
     },
   ],
 };

--- a/src/types_26.ts
+++ b/src/types_26.ts
@@ -1,0 +1,14 @@
+import type { RegistryTypes } from "@polkadot/types/types";
+import { types25 } from "./types_25";
+
+export const types26: RegistryTypes = {
+  ...types25,
+  DidAuthorizedCallOperation: {
+    did: "DidIdentifierOf",
+    txCounter: "u64",
+    call: "DidCallableOf",
+    // Added
+    blockNumber: "BlockNumber",
+    submitter: "AccountId",
+  },
+};


### PR DESCRIPTION
They have been already tested in the SDK with a local instance of the node running version 26 and it is working fine (i.e., integration tests go through).

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
