### PR TITLE
feat: add new type definitions for public credential RPC endpoints

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { types2700 } from "./types_2700"
 import { types10700 } from "./types_10700"
 
 import runtime from "./runtime"
+import rpc from "./rpc"
 
 // Export type definitions
 export {
@@ -36,6 +37,9 @@ export {
 
 // Export runtime APIs definitions
 export { runtime }
+
+// Export custom RPC definitions
+export { rpc }
 
 // Export complete package
 export const typeBundleForPolkadot: OverrideBundleDefinition = {
@@ -93,5 +97,6 @@ export const typeBundleForPolkadot: OverrideBundleDefinition = {
       types: types10700,
     },
   ],
-  runtime: runtime
+  runtime: runtime,
+  rpc: rpc
 }

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -1,0 +1,45 @@
+import type {
+  DefinitionRpc, DefinitionRpcSub
+} from "@polkadot/types/types"
+
+const rpc: Record<string, Record<string, DefinitionRpc | DefinitionRpcSub>> = {
+  credentials: {
+    getCredential: {
+      description: "Test",
+      params: [
+        {
+          name: "credential_id",
+          type: "Hash",
+        },
+        {
+          name: "at",
+          type: "Hash",
+          isOptional: true,
+        },
+      ],
+      type: "Option<PublicCredentialsCredentialsCredentialEntry>"
+    },
+    getCredentials: {
+      description: "Return all the credentials issued to the provided subject, optionally filtering with the provided logic.",
+      params: [
+        {
+          name: "subject",
+          type: "String",
+        },
+        {
+          name: "filter",
+          type: "PublicCredentialFilter",
+          isOptional: true,
+        },
+        {
+          name: "at",
+          type: "Hash",
+          isOptional: true,
+        },
+      ],
+      type: "Vec<(Hash, PublicCredentialsCredentialsCredentialEntry)>"
+    }
+  }
+}
+
+export default rpc

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -40,6 +40,33 @@ const runtime: DefinitionsCall = {
       version: 1
     }
   ],
+  PublicCredentialsApi: [
+    {
+      methods: {
+        get_credential: {
+          description: "Test",
+          params: [
+            {
+              name: "credentialId",
+              type: "Hash",
+            },
+          ],
+          type: "Option<PublicCredentialsCredentialsCredentialEntry>"
+        },
+        get_credentials: {
+          description: "Test",
+          params: [
+            {
+              name: "subject",
+              type: "RuntimeCommonAssetsAssetDid",
+            },
+          ],
+          type: "Vec<(Hash, PublicCredentialsCredentialsCredentialEntry)>"
+        },
+      },
+      version: 1
+    }
+  ],
 }
 
 export default runtime

--- a/src/types_10700.ts
+++ b/src/types_10700.ts
@@ -25,4 +25,12 @@ export const types10700: RegistryTypes = {
     lastTxCounter: "BlockNumber",
     deposit: "KiltSupportDeposit<AccountId32, Balance>"
   },
+
+  // Public credentials RPC
+  PublicCredentialFilter: {
+    _enum: {
+      ctypeHash: "Hash",
+      attester: "DidIdentifier",
+    }
+  }
 }


### PR DESCRIPTION
This PR is based on top of https://github.com/KILTprotocol/type-definitions/pull/32 (so please merge that one first).

It adds type definitions and RPC decorations for the new public credentials RPC endpoints as defined in https://github.com/KILTprotocol/kilt-node/pull/378 and https://github.com/KILTprotocol/kilt-node/pull/392.