### PR TITLE
feat: add dev package release from new develop branch

### DIFF
--- a/.github/workflows/devpublish.yml
+++ b/.github/workflows/devpublish.yml
@@ -1,0 +1,39 @@
+name: dev release
+on:
+  push:
+    branches:
+      - develop
+jobs:
+  build:
+    if: "! startsWith(github.event.head_commit.message, '[CI Skip]')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Bump prerelease version of root package
+        run: npm version --no-git-tag-version prerelease
+      - name: Get current package version
+        id: package_version
+        run: echo "::set-output name=package_version::$(node -pe "require('./package.json').version")"        
+      - name: Export package version
+        env:
+          PACKAGE_VERSION: ${{ steps.package_version.outputs.package_version }}
+      - name: Build package
+        run: yarn run build
+      - name: Publish to NPM
+        run: npm publish --tag dev
+        env:
+          NODE_AUTH_TOKEN : ${{ secrets.NPM_TOKEN }}
+      - name: Commit files
+        run: |
+          git config --local user.name "Github Action"
+          git config --local user.email "action@github.com"
+          git add .
+          git commit -m "[CI Skip] ci: publish prerelease" -n
+          git push          


### PR DESCRIPTION
Since we need to use this repo again for RPC and runtime calls, I created a `develop` branch as the default which mirrors what we do in the SDK and in the node repos. The goal is that of having a `master` branch of types that can be used by the `master` branch of the SDK and that work with the `master` (or latest released) version of the chain. Similarly, the `develop` branch must be compatible with the SDK and node `develop` branches.

This PR introduces a GH action that pushes dev packages whenever something is pushed to the `develop` branch, very similarly to what we do for the SDK.